### PR TITLE
changed cards to be their own columns so they stack across the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,11 +111,11 @@
         <!-- placeholder end -->
       </section>
 
+      <!-- example card start -->
       <!-- container for search result cards -- col -->
-      <section class="w3-col s12 l6 w3-padding w3-margin-bottom w3-margin-top">
-        <!-- example card start -->
+      <article class="w3-col s12 l6 w3-padding">
         <!-- card container -->
-        <article class="w3-card-4 w3-row w3-margin-bottom">
+        <div class="w3-card-4 w3-margin-bottom">
           <header class="w3-container w3-light-grey">
             <!-- element for results[i].legalBusinessName -->
             <h3 class="w3-medium">legalBusinessName</h3>
@@ -140,15 +140,19 @@
           <button class="w3-button w3-block w3-dark-grey">
             button that does something
           </button>
-        </article>
-
-        <!-- example card start -->
-        <article class="w3-card-4 w3-row w3-margin-bottom">
+        </div>
+      </article>
+      <!-- container for search result cards -- col -->
+      <article class="w3-col s12 l6 w3-padding">
+        <!-- card container -->
+        <div class="w3-card-4 w3-margin-bottom">
           <header class="w3-container w3-light-grey">
-            <h3 class="w3-medium">Example</h3>
+            <!-- element for results[i].legalBusinessName -->
+            <h3 class="w3-medium">legalBusinessName</h3>
           </header>
           <div class="w3-container">
-            <p class="w3-small">Category</p>
+            <!-- element for  -->
+            <p class="w3-small">info</p>
             <hr />
             <img
               src="https://picsum.photos/60"
@@ -156,8 +160,6 @@
               class="w3-left w3-circle w3-margin-right w3-margin-bottom"
             />
             <p class="w3-small">
-              Landscaping services
-              <br />
               12345 Decker Ln.
               <br />
               Austin, TX
@@ -168,8 +170,130 @@
           <button class="w3-button w3-block w3-dark-grey">
             button that does something
           </button>
-        </article>
-      </section>
+        </div>
+      </article>
+            <!-- container for search result cards -- col -->
+            <article class="w3-col s12 l6 w3-padding">
+              <!-- card container -->
+              <div class="w3-card-4 w3-margin-bottom">
+                <header class="w3-container w3-light-grey">
+                  <!-- element for results[i].legalBusinessName -->
+                  <h3 class="w3-medium">legalBusinessName</h3>
+                </header>
+                <div class="w3-container">
+                  <!-- element for  -->
+                  <p class="w3-small">info</p>
+                  <hr />
+                  <img
+                    src="https://picsum.photos/60"
+                    alt="icon/img"
+                    class="w3-left w3-circle w3-margin-right w3-margin-bottom"
+                  />
+                  <p class="w3-small">
+                    12345 Decker Ln.
+                    <br />
+                    Austin, TX
+                    <br />
+                    78724
+                  </p>
+                </div>
+                <button class="w3-button w3-block w3-dark-grey">
+                  button that does something
+                </button>
+              </div>
+            </article>
+                  <!-- container for search result cards -- col -->
+      <article class="w3-col s12 l6 w3-padding">
+        <!-- card container -->
+        <div class="w3-card-4 w3-margin-bottom">
+          <header class="w3-container w3-light-grey">
+            <!-- element for results[i].legalBusinessName -->
+            <h3 class="w3-medium">legalBusinessName</h3>
+          </header>
+          <div class="w3-container">
+            <!-- element for  -->
+            <p class="w3-small">info</p>
+            <hr />
+            <img
+              src="https://picsum.photos/60"
+              alt="icon/img"
+              class="w3-left w3-circle w3-margin-right w3-margin-bottom"
+            />
+            <p class="w3-small">
+              12345 Decker Ln.
+              <br />
+              Austin, TX
+              <br />
+              78724
+            </p>
+          </div>
+          <button class="w3-button w3-block w3-dark-grey">
+            button that does something
+          </button>
+        </div>
+      </article>
+            <!-- container for search result cards -- col -->
+            <article class="w3-col s12 l6 w3-padding">
+              <!-- card container -->
+              <div class="w3-card-4 w3-margin-bottom">
+                <header class="w3-container w3-light-grey">
+                  <!-- element for results[i].legalBusinessName -->
+                  <h3 class="w3-medium">legalBusinessName</h3>
+                </header>
+                <div class="w3-container">
+                  <!-- element for  -->
+                  <p class="w3-small">info</p>
+                  <hr />
+                  <img
+                    src="https://picsum.photos/60"
+                    alt="icon/img"
+                    class="w3-left w3-circle w3-margin-right w3-margin-bottom"
+                  />
+                  <p class="w3-small">
+                    12345 Decker Ln.
+                    <br />
+                    Austin, TX
+                    <br />
+                    78724
+                  </p>
+                </div>
+                <button class="w3-button w3-block w3-dark-grey">
+                  button that does something
+                </button>
+              </div>
+            </article>
+                  <!-- container for search result cards -- col -->
+      <article class="w3-col s12 l6 w3-padding">
+        <!-- card container -->
+        <div class="w3-card-4 w3-margin-bottom">
+          <header class="w3-container w3-light-grey">
+            <!-- element for results[i].legalBusinessName -->
+            <h3 class="w3-medium">legalBusinessName</h3>
+          </header>
+          <div class="w3-container">
+            <!-- element for  -->
+            <p class="w3-small">info</p>
+            <hr />
+            <img
+              src="https://picsum.photos/60"
+              alt="icon/img"
+              class="w3-left w3-circle w3-margin-right w3-margin-bottom"
+            />
+            <p class="w3-small">
+              12345 Decker Ln.
+              <br />
+              Austin, TX
+              <br />
+              78724
+            </p>
+          </div>
+          <button class="w3-button w3-block w3-dark-grey">
+            button that does something
+          </button>
+        </div>
+      </article>
+      <!-- example card end -->
+
 
       <section id="mission">
         <p>


### PR DESCRIPTION
On large screen size, the search result divs were only stacking on right side of screen. changed the result to be a stand alone column <article> so it stacks across the screen when on large screen

This should be the last time the example result div is changed! 🤞🏽